### PR TITLE
updated install_requirement.sh to BCM version 1.75 and changed the CFLAG

### DIFF
--- a/src/framework/raspberrypi/install_requirements.sh
+++ b/src/framework/raspberrypi/install_requirements.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BCM_VERSION=1.68
+BCM_VERSION=1.75
 if [ "$EUID" -eq 0 ]
 then
 	echo "Please do not execute this script as root."
@@ -21,7 +21,7 @@ done
 
 if [[ $menuinput == 'Y' || $menuinput == 'y' ]]
 then
-	CFLAGS='-DBCM2835_HAVE_LIBCAP'
+	CFLAGS="-fPIC -DBCM2835_HAVE_LIBCAP"
 	echo "Installing required packets..."
 	sudo apt-get install libcap2 libcap-dev
 	echo "Add current user to kmem group..."
@@ -39,7 +39,7 @@ echo "Compiling BCM2835 library..."
 tar zxvf bcm2835-$BCM_VERSION.tar.gz
 cd bcm2835-$BCM_VERSION
 
-./configure CFLAGS=$CFLAGS
+./configure CFLAGS="$CFLAGS"
 make
 
 echo "Installing BCM2835 library..."


### PR DESCRIPTION
This pull request introduces improvements to the script:

1. Version Update:

The BCM2835 library version has been updated from 1.68 to 1.75. 

2. Virtual Environment: 
The CFLAGS variable now includes both -fPIC and -DBCM2835_HAVE_LIBCAP flags when enabling non-root access.
