### PR TITLE
Bcm2835 spi clock divider

### DIFF
--- a/src/framework/raspberrypi/pal/spic-rpi.cpp
+++ b/src/framework/raspberrypi/pal/spic-rpi.cpp
@@ -14,7 +14,7 @@
  * This function sets the basics for a SPIC and the default SPI.
  *
  */
-SPICRpi::SPICRpi() : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_16)
+SPICRpi::SPICRpi() : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_128)
 {
 
 }
@@ -28,7 +28,7 @@ SPICRpi::SPICRpi() : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1
  * @param mode   SPI mode
  * @param clock  SPI clock divider
  */
-SPICRpi::SPICRpi(uint8_t lsb, uint8_t mode, uint8_t clock) : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_16)
+SPICRpi::SPICRpi(uint8_t lsb, uint8_t mode, uint8_t clock) : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_128)
 {
 	this->lsb = lsb;
 	this->mode = mode;
@@ -46,7 +46,7 @@ SPICRpi::SPICRpi(uint8_t lsb, uint8_t mode, uint8_t clock) : lsb(BCM2835_SPI_BIT
  * @param mosiPin  mosi pin number
  * @param sckPin   systemclock pin number
  */
-SPICRpi::SPICRpi(uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_16)
+SPICRpi::SPICRpi(uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_128)
 {
 	this->csPin = csPin;
 	this->misoPin = misoPin;
@@ -74,7 +74,7 @@ Error_t SPICRpi::init()
         }
 	bcm2835_spi_setBitOrder(BCM2835_SPI_BIT_ORDER_LSBFIRST);      // The default
 	bcm2835_spi_setDataMode(BCM2835_SPI_MODE1);                   // The default
-    bcm2835_spi_setClockDivider(BCM2835_SPI_CLOCK_DIVIDER_32);
+    bcm2835_spi_setClockDivider(BCM2835_SPI_CLOCK_DIVIDER_128);
     bcm2835_spi_chipSelect(BCM2835_SPI_CS0);                      // The default
     bcm2835_spi_setChipSelectPolarity(BCM2835_SPI_CS0, LOW);      // The default
 	return OK;


### PR DESCRIPTION
changed clock divider from 16 to 128.

Reason with a clock divider from 16 we have a frequency of 31.25 MHz. This is more than the Chip supports.
Picture of the Clock frequency with a clock divider 16.
<img width="913" height="125" alt="image" src="https://github.com/user-attachments/assets/df5de084-b475-40a4-832c-3746757e9193" />

I changed it to 128 so that we have a frequency of 3.9 MHz.
This is below the supportet maximum of 5 MHz (https://www.infineon.com/assets/row/public/documents/10/49/infineon-tle94112es-datasheet-en.pdf?fileId=5546d462773f9324017743803d61428d page 2)

 