### PR TITLE
Fixes in cmakelists, setup.py and pyproject

### DIFF
--- a/src/framework/raspberrypi/CMakeLists.txt
+++ b/src/framework/raspberrypi/CMakeLists.txt
@@ -8,12 +8,6 @@ include_directories(
     wrapper/
 )
 
-
-set(Headers
-    pal/
-    wrapper/
-    )
-
 set(Sources
     pal/gpio-rpi.cpp
     pal/logger-rpi.cpp

--- a/src/framework/raspberrypi/CMakeLists.txt
+++ b/src/framework/raspberrypi/CMakeLists.txt
@@ -15,9 +15,6 @@ set(Sources
     pal/timer-rpi.cpp
     wrapper/tle94112-rpi.cpp
     wrapper/tle94112-pybind.cpp
-    ../../corelib/tle94112.cpp
-    ../../corelib/tle94112-motor.cpp
-    ../../corelib/tle94112-logger.cpp
     )
 
 # add_subdirectory(tools/pybind11)

--- a/src/framework/raspberrypi/CMakeLists.txt
+++ b/src/framework/raspberrypi/CMakeLists.txt
@@ -15,6 +15,9 @@ set(Sources
     pal/timer-rpi.cpp
     wrapper/tle94112-rpi.cpp
     wrapper/tle94112-pybind.cpp
+    ../../corelib/tle94112.cpp
+    ../../corelib/tle94112-motor.cpp
+    ../../corelib/tle94112-logger.cpp
     )
 
 # add_subdirectory(tools/pybind11)

--- a/src/framework/raspberrypi/CMakeLists.txt
+++ b/src/framework/raspberrypi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4...3.18)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(multi_half_bridge_py)
 
@@ -23,7 +23,7 @@ set(Sources
 # add_subdirectory(tools/pybind11)
 find_package(pybind11 REQUIRED)
 
-pybind11_add_module(multi_half_bridge_py ${Sources} ${Headers})
+pybind11_add_module(multi_half_bridge_py ${Sources})
 
 # Adding RPI bcm library dependency
 find_library(bcm2835_dir NAMES  libbcm2835.a)
@@ -36,6 +36,7 @@ set_target_properties(bcm2835 PROPERTIES IMPORTED_LOCATION ${bcm2835_dir})
 target_link_libraries(multi_half_bridge_py PUBLIC
 multi-half-bridge-corelib
 bcm2835
+cap
 )
 
 # EXAMPLE_VERSION_INFO is defined by setup.py and passed into the C++ code as a

--- a/src/framework/raspberrypi/pyproject.toml
+++ b/src/framework/raspberrypi/pyproject.toml
@@ -4,5 +4,6 @@ requires = [
     "wheel",
     "ninja; sys_platform != 'win32'",
     "cmake>=3.12",
+    "pybind11>=2.13.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/src/framework/raspberrypi/setup.py
+++ b/src/framework/raspberrypi/setup.py
@@ -105,6 +105,18 @@ class CMakeBuild(build_ext):
         subprocess.check_call(
             ["cmake", "--build", ".", "--target", "multi_half_bridge_py"] + build_args, cwd=self.build_temp
         )
+        
+        import glob
+        built_so_files = glob.glob(os.path.join(self.build_temp, "**", "*.so"), recursive=True)
+        if built_so_files:
+            # Get the expected output directory for this extension
+            expected_dir = os.path.dirname(self.get_ext_fullpath(ext.name))
+            if not os.path.exists(expected_dir):
+                os.makedirs(expected_dir)
+            
+            # Copy the .so file to the expected location
+            import shutil
+            shutil.copy2(built_so_files[0], self.get_ext_fullpath(ext.name))
 
 # The information here can also be placed in setup.cfg - better separation of
 # logic and declaration, and simpler if you include description/version in a file.

--- a/src/framework/raspberrypi/setup.py
+++ b/src/framework/raspberrypi/setup.py
@@ -105,6 +105,9 @@ class CMakeBuild(build_ext):
             ["cmake", "--build", ".", "--target", "multi_half_bridge_py"] + build_args, cwd=self.build_temp
         )
         
+        # This is needed to find the built .so file and copy it to the expected location
+        # without that it would compile but you can not use the module
+
         import glob
         built_so_files = glob.glob(os.path.join(self.build_temp, "**", "*.so"), recursive=True)
         if built_so_files:

--- a/src/framework/raspberrypi/setup.py
+++ b/src/framework/raspberrypi/setup.py
@@ -129,7 +129,7 @@ setup(
     project_urls={
         'Source' : 'https://github.com/Infineon/multi-half-bridge',
         'Wiki': 'https://github.com/Infineon/multi-half-bridge/wiki',
-        'IC Prodcuts Page' : 'https://www.infineon.com/cms/de/product/power/motor-control-ics/brushed-dc-motor-driver-ics/multi-half-bridge-ics/'
+        'IC Products Page' : 'https://www.infineon.com/cms/de/product/power/motor-control-ics/brushed-dc-motor-driver-ics/multi-half-bridge-ics/'
     },
     ext_modules=[CMakeExtension("multi_half_bridge_py", "../../..")],
     cmdclass={"build_ext": CMakeBuild},

--- a/src/framework/raspberrypi/setup.py
+++ b/src/framework/raspberrypi/setup.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import subprocess
+import pybind11  # added: direct import to obtain CMake config dir
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
@@ -39,11 +40,8 @@ class CMakeBuild(build_ext):
         # Can be set with Conda-Build, for example.
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
 
-        # Ensure necessary environment variables are set
-        cmake_prefix_path = subprocess.check_output(
-            [sys.executable, "-m", "pybind11", "--cmakedir"]
-        ).strip().decode()
-        os.environ["CMAKE_PREFIX_PATH"] = cmake_prefix_path
+        # Get pybind11 CMake package directory 
+        pybind11_dir = pybind11.get_cmake_dir()
        
 
         # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
@@ -54,6 +52,7 @@ class CMakeBuild(build_ext):
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
             "-DEXAMPLE_VERSION_INFO={}".format(self.distribution.get_version()),
             "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
+            f"-Dpybind11_DIR={pybind11_dir}",
         ]
         build_args = []
 

--- a/src/framework/raspberrypi/setup.py
+++ b/src/framework/raspberrypi/setup.py
@@ -39,6 +39,13 @@ class CMakeBuild(build_ext):
         # Can be set with Conda-Build, for example.
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
 
+        # Ensure necessary environment variables are set
+        cmake_prefix_path = subprocess.check_output(
+            [sys.executable, "-m", "pybind11", "--cmakedir"]
+        ).strip().decode()
+        os.environ["CMAKE_PREFIX_PATH"] = cmake_prefix_path
+       
+
         # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
         # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
         # from Python.
@@ -112,7 +119,7 @@ setup(
         'Wiki': 'https://github.com/Infineon/multi-half-bridge/wiki',
         'IC Prodcuts Page' : 'https://www.infineon.com/cms/de/product/power/motor-control-ics/brushed-dc-motor-driver-ics/multi-half-bridge-ics/'
     },
-    ext_modules=[CMakeExtension("multi_half_bridge_py")],
+    ext_modules=[CMakeExtension("multi_half_bridge_py", "../../..")],
     cmdclass={"build_ext": CMakeBuild},
     license='MIT',
     url='https://pypi.org/project/multi-half-bridge/',


### PR DESCRIPTION
changes in CMakeLists.txt, pyproject.toml and setup.py:

pyproject.toml:
- added pybind11 in this list

CMakeLists.txt:
- changed the needed CMake version to the same as in the CMakelists in the beginning
- removed set(Headers ...), because it is not needed. These folders are already included with include_directories(...
- added in target_link_libraries: cap (this is needed that root privileges are not needed, so that it compiles  on virtual environments

setup.py:
- added code that insures that cmake find the pybind11 installation path
- Added copying of compiled ".so" files to their expected locations to ensure package functionality
- changed CMakelists.txt path (now the stup.py uses the core CMakelists.txt which is 3 folder below this setup)
- corrected a spelling mistake: Prodcuts --> Products






